### PR TITLE
Fixing typo for env_setup instructions local_03_create_env.md

### DIFF
--- a/boat_tutorials/env_setup/local_03_create_env.md
+++ b/boat_tutorials/env_setup/local_03_create_env.md
@@ -79,6 +79,7 @@ Check out Project [Jupyter](https://jupyter.org/) to understand the Jupyter ecos
 :::
 
 Let's now we launch the JupyterLab:
+
     ```shell
     $ jupyter lab
     ```

--- a/boat_tutorials/env_setup/local_03_create_env.md
+++ b/boat_tutorials/env_setup/local_03_create_env.md
@@ -78,11 +78,10 @@ Now that we have create a conda environment for running the tutorials, let's tes
 Check out Project [Jupyter](https://jupyter.org/) to understand the Jupyter ecosystem!
 :::
 
-Let's now we launch the JupyterLab:
-
-    ```shell
-    $ jupyter lab
-    ```
+Let's now launch the JupyterLab:
+```shell
+$ jupyter lab
+```
 
 You should be taken to a website as shown below:
 

--- a/boat_tutorials/env_setup/local_03_create_env.md
+++ b/boat_tutorials/env_setup/local_03_create_env.md
@@ -78,7 +78,7 @@ Now that we have create a conda environment for running the tutorials, let's tes
 Check out Project [Jupyter](https://jupyter.org/) to understand the Jupyter ecosystem!
 :::
 
-Let's now launch the JupyterLab:
+Let's now launch the JupyterLab by running below in the terminal:
 ```shell
 $ jupyter lab
 ```


### PR DESCRIPTION
Found a place in `local_03_create_env.md` where:
```shell
$ jupyter lab
```

was showing up as ```shell      $ jupyter lab      ```

Fixing that typo with this PR
